### PR TITLE
option to configure IPv6 addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,18 +2,27 @@ Usage
 =====
 
 ```
-domain-connect-dyndns [-h] [--config CONFIG] (--domain DOMAIN | --all) {setup,update,status}
+domain-connect-dyndns [-h] [--config CONFIG] [--ignore-previous-ip]
+                      [--ignore-ipv4] [--ignore-ipv6]
+                      (--domain DOMAIN | --all)
+                      {setup,update,status}
 ```
 
-Positional arguments:
-- {setup,update, status} --- action on domain
+**Positional arguments:**
 
-Optional arguments:
-- --config CONFIG --- config file path
-- --domain DOMAIN --- domain to keep up to date
-- --all --- update all domains in config
-- -h --- display help and exit
+`{setup, update, status}` - action on domain
 
+**Optional arguments:**
+
+```
+--config CONFIG         --- config file path
+--domain DOMAIN         --- domain to keep up to date
+--all                   --- update all domains in config
+--ignore-previous-ip    --- update the IP even if no change detected.
+--ignore-ipv4           --- ignore IPv4 Protocol on setup
+--ignore-ipv6           --- ignore IPv6 Protocol on setup
+-h                      --- display help and exit
+```
 
 Installation
 ============

--- a/dyndns/command_line.py
+++ b/dyndns/command_line.py
@@ -14,7 +14,8 @@ def main():
     parser.add_argument('--config', type=str, default='settings.txt', help="config file path")
     parser.add_argument('--ignore-previous-ip', action='store_true', dest='ignore_previous_ip',
                         help="Update the IP even if no change detected. Don't use on regular update!")
-
+    parser.add_argument('--ignore-ipv4', action='store_true', dest='ignore_ipv4', help="Dont update IPv4 addresses")
+    parser.add_argument('--ignore-ipv6', action='store_true', dest='ignore_ipv6', help="Dont update IPv6 addresses")
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument('--domain', type=str, help="domain to keep up to date")
     group.add_argument('--all', action='store_true', help="update all domains in config")
@@ -26,6 +27,8 @@ def main():
     all = args.all
     settings = args.config
     ignore_previous_ip = args.ignore_previous_ip
+    ignore_ipv4 = args.ignore_ipv4
+    ignore_ipv6 = args.ignore_ipv6
 
     # validate domain
     if domain and not validators.domain(domain) is True:
@@ -39,6 +42,12 @@ def main():
     if ignore_previous_ip and action != 'update':
         print("--ignore-previous-ip only valid with update action")
         return
+
+    protocols = ['IPv4', 'IPv6']
+    if ignore_ipv4:
+        protocols.remove('IPv4')
+    if ignore_ipv6:
+        protocols.remove('IPv6')
 
     domains = []
     if all:
@@ -56,7 +65,7 @@ def main():
 
     for domain in domains:
         if action == 'setup':
-            print(domain_setup.main(domain, settings))
+            print(domain_setup.main(domain, protocols, settings))
         elif action == 'update':
             print(domain_update.main(domain, settings, ignore_previous_ip))
         elif action == 'status':

--- a/dyndns/domain_setup.py
+++ b/dyndns/domain_setup.py
@@ -10,7 +10,7 @@ import webbrowser
 dc = DomainConnect()
 
 
-def main(domain, settings='settings.txt'):
+def main(domain, protocols, settings='settings.txt'):
     # get Domain Connect config
     try:
         config = dc.get_domain_config(domain)
@@ -74,7 +74,8 @@ def main(domain, settings='settings.txt'):
                 'access_token': context.access_token,
                 'refresh_token': context.refresh_token,
                 'iat': context.iat,
-                'access_token_expires_in': context.access_token_expires_in
+                'access_token_expires_in': context.access_token_expires_in,
+                'protocols': protocols
             }
         })
         json.dump(existing_config, settings_file, sort_keys=True, indent=1)

--- a/dyndns/domain_setup.py
+++ b/dyndns/domain_setup.py
@@ -26,7 +26,7 @@ def main(domain, settings='settings.txt'):
             domain=domain,
             provider_id='domainconnect.org',
             service_id_in_path=True,
-            service_id='dynamicdns',
+            service_id='dynamicdns-v2',
             params=params,
             redirect_uri='https://dynamicdns.domainconnect.org/ddnscode'
         )
@@ -34,7 +34,7 @@ def main(domain, settings='settings.txt'):
         context = dc.get_domain_connect_template_async_context(
             domain=domain,
             provider_id='domainconnect.org',
-            service_id=['dynamicdns',],
+            service_id=['dynamicdns-v2'],
             params=params,
             redirect_uri='https://dynamicdns.domainconnect.org/ddnscode'
         )

--- a/dyndns/domain_status.py
+++ b/dyndns/domain_status.py
@@ -24,7 +24,15 @@ def main(domain, settings='settings.txt'):
         info['Last DNS check'] = datetime.datetime.fromtimestamp(config[domain]['last_dns_check']) \
             .strftime("%d %B %Y %H:%M")
     if 'ip' in config[domain]:
-        info['IP value'] = config[domain]['ip']
+        if isinstance(config[domain]['ip'], basestring):
+            info['IPv4 value'] = config[domain]['ip']
+        if 'IP' in config[domain]['ip']:
+            info['IPv4 value'] = config[domain]['ip']['IP']
+        if 'IPv4' in config[domain]['ip']:
+            info['IPv4 value'] = config[domain]['ip']['IPv4']
+        if 'IPv6' in config[domain]['ip']:
+            info['IPv6 value'] = config[domain]['ip']['IPv6']
+
     if 'last_success' in config[domain]:
         info['Last DNS succesful update'] = datetime.datetime.fromtimestamp(config[domain]['last_success']) \
             .strftime("%d %B %Y %H:%M")

--- a/dyndns/domain_update.py
+++ b/dyndns/domain_update.py
@@ -144,5 +144,5 @@ def main(domain, settings='settings.txt', ignore_previous_ip=False):
         json.dump(config, settings_file, sort_keys=True, indent=1)
 
     if success:
-        return "DNS record successfully updated."
-    return "Could not update DNS record."
+        return "DNS records successfully updated."
+    return "Could not update DNS records."

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ unittest2==1.1.0
 validators==0.12.6
 mock==2.0.0
 requests==2.21.0
+ipaddress==1.0.23; python_version < '3.3'

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
         'requests >= 2.21.0',
         'dnspython >= 1.15.0',
         'domain-connect >= 0.0.7',
+        'ipaddress >= 1.0.23;python_version<"3.3"',
     ],
     entry_points = {
         'console_scripts': ['domain-connect-dyndns=dyndns.command_line:main'],


### PR DESCRIPTION
Hi, 
I added the option to configure IPv6 addresses with the domainconnect python client. 
A short summary of actions:
- **you setup a new domain:** 
great, you get by default ipv4 and ipv6 with the template `dynamicdns-v2`
- **you update a domain with existing (old) config:**
you continue to use the old `dynamicdns` template and update your ipv4 like ever since, no difference to see. You want ipv6? Great, delete your domain-config and rerun setup.
- **you want to setup only ipv4?**
Simply use the parameter `--ignore-ipv6` on domain setup
- **you want to setup only ipv6?**
Simply use the parameter `--ignore-ipv4` on domain setup

Tried it with the german provider IONOS/1and1 , works like a charm!
  
Motivation: #22