### PR TITLE
BUGFIX: Ignore if webbrowser doesn't exist. Solves #46

### DIFF
--- a/dyndns/domain_setup.py
+++ b/dyndns/domain_setup.py
@@ -1,6 +1,10 @@
 import json
 import os.path
-import webbrowser
+try:
+    import webbrowser
+except ModuleNotFoundError:
+    pass
+import sys
 from builtins import input
 
 from domainconnect import DomainConnect, DomainConnectAsyncCredentials, TemplateNotSupportedException, \
@@ -43,8 +47,8 @@ def main(domain, protocols, settings='settings.txt'):
             params=params,
             redirect_uri='https://dynamicdns.domainconnect.org/ddnscode'
         )
-
-    webbrowser.open(context.asyncConsentUrl, autoraise=True)
+    if "webbrowser" in sys.modules:
+        webbrowser.open(context.asyncConsentUrl, autoraise=True)
     code = input("Please open\n{}\nand provide us the access code:".format(context.asyncConsentUrl))
 
     tries = 1


### PR DESCRIPTION
This enables this to run on OpenWrt and similar platforms which don't include the webbrowser library, which isn't fully neccessary for the program to run. It just ignores the `ModuleNotFoundError` and doesn't run the line which launches the web browser. Solves the issue #46.